### PR TITLE
Feature: Monitoring Stack - Prometheus and Grafana

### DIFF
--- a/kubernetes/namespaces.yaml
+++ b/kubernetes/namespaces.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: logging

--- a/kubernetes/prometheus-values.yaml
+++ b/kubernetes/prometheus-values.yaml
@@ -1,0 +1,13 @@
+grafana:
+  adminPassword: admin123
+  service:
+    type: LoadBalancer
+
+prometheus:
+  service:
+    type: LoadBalancer
+  prometheusSpec:
+    retention: 7d
+
+alertmanager:
+  enabled: false


### PR DESCRIPTION
## Summary
Deployed Prometheus and Grafana monitoring stack on EKS using Helm

## Changes
- Added monitoring and logging namespaces
- Configured kube-prometheus-stack Helm values
- Deployed Prometheus for metrics collection
- Deployed Grafana with pre-built Kubernetes dashboards
- Configured LoadBalancer access for both services

## Configuration
- Prometheus: Ephemeral storage for demo purposes
- Grafana: Admin access configured
- AlertManager: Disabled for simplicity
- Node exporters running on all nodes

## Testing
- All pods running successfully in monitoring namespace
- Grafana dashboards displaying cluster metrics
- Prometheus scraping targets successfully